### PR TITLE
Changes the temporary dir location to work on every system

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,6 @@
 const argv = require("minimist")(process.argv.slice(2));
 const path = require("path");
+const os   = require("os");
 
 const src = argv.src || argv._.shift();
 // Directories
@@ -19,7 +20,7 @@ const dirs =
   browserifyDir: `${themeDir}/js`,
   browserifyTargetDir: `${publicDir}/js`,
   localesDir: `${srcPath}/locales`,
-  tempDir: `${srcPath}/temp`
+  tempDir: `${os.tmpdir()}/${process.pid}`
 };
 
 // Default port

--- a/lib/example.js
+++ b/lib/example.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const request = require("request");
-const {removeSync, moveSync} = require("fs-extra");
+const {removeSync, moveSync, pathExistsSync} = require("fs-extra");
 const admZip = require("adm-zip");
 const {srcPath, tempDir} = require("../config").dirs;
 const tempZip = `${tempDir}/tmp.zip`;
@@ -20,12 +20,19 @@ const createExampleProject = () =>
       console.log("Zip file downloaded. Extracting...");
       const zip = new admZip(tempZip);
       const mainEntry = zip.getEntries()[0].entryName;
-      zip.extractAllTo(srcPath, true);
+      zip.extractAllTo(tempDir, true);
+      moveSync(path.join(tempDir, mainEntry), srcPath);
       removeSync(tempDir);
-      moveSync(path.join(srcPath, mainEntry), srcPath);
       console.log("Example is extracted");
       process.exit();
     });
 }
+
+process.on("uncaughtException", (e) => {
+  console.log(e);
+  if (pathExistsSync(tempDir))
+    removeSync(tempDir);
+  process.exit(1);
+});
 
 module.exports = {createExampleProject};


### PR DESCRIPTION
* uses the system temp dir + pid combination to avoid renaming child
folder to a parent folder, which fails on linux;
* cleans up the temporary folder during emergency shutdown to avoid
leaving orphan files;
* still fails on linux when providing existing folder to the example
command;
* still does not initialize modules for the cloned example.