### PR TITLE
[WIP]Refactor the server and fix #106

### DIFF
--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -1,0 +1,23 @@
+const noaction = (req, res, next) => {};
+
+const build = (handlers) => {
+    if (handlers.length === 0) {
+        return noaction;
+    }
+
+    const [current, ...remaining] = handlers;
+    const next = build(remaining);
+
+    return (req, res) => current(req, res, () => Promise.resolve(next(req, res)));
+};
+
+const composeMiddleware = (...handlers) => {
+    return (req, res) => Promise.resolve(build(handlers)(req, res));
+};
+
+const logRequestUrl = (req, res, next) => {
+    console.log(`Serving: ${req.url}`);
+    next();
+};
+
+module.exports = {composeMiddleware, logRequestUrl};

--- a/lib/server.js
+++ b/lib/server.js
@@ -13,6 +13,7 @@ const {ensureDirSync} = require("fs-extra");
 const glob = promisify(require("glob").glob);
 const stream = require("stream");
 const {Readable} = stream;
+const {composeMiddleware, logRequestUrl} = require("../lib/middlewares");
 // Configurations
 const config = require("../config");
 const {pageExtestions, multiLang, gzip} = config;
@@ -24,10 +25,13 @@ const gzipExt = ".gzip";
 const staticExt = ".html";
 let staticGenCallback = null;
 
-const resourcesMap = {
-  ".html": {encoding: "utf-8", type: "text/html"},
+const compiledResourcesMap = {
   ".ejs": {encoding: "utf-8", type: "text/html"},
-  ".md": {encoding: "utf-8", type: "text/html"},
+  ".md": {encoding: "utf-8", type: "text/html"}
+};
+
+const staticResourcesMap = {
+  ".html": {encoding: "utf-8", type: "text/html"},
   ".js": {encoding: "utf-8", type: "text/javascript"},
   ".css": {encoding: "utf-8", type: "text/css"},
   ".txt": {encoding: "utf-8", type: "text/plain"},
@@ -45,12 +49,109 @@ const resourcesMap = {
   ".zip": {encoding: "binary", type: "application/zip"}
 };
 
+const resourcesMap = {...compiledResourcesMap, ...staticResourcesMap};
+
 // Caching the request
 let isCache = false;
 // Static content generation
 let isStatic = false;
 // Static content generation stack
 let staticStack = [];
+
+const getLocaleMiddleware = useMultiLang => {
+  if (!useMultiLang)
+    return (req, res, next) => next();
+
+  return (req, res, next) => {
+    req.locale = getLocaleFromPath(req.url);
+
+    // Prefer accept-language header if no locale in the path
+    if (!req.locale) {
+      const page = url.parse(req.url).pathname;
+      const acceptLanguage = getHeaders(req)["accept-language"];
+      req.locale = getLocaleFromHeader([defaultLocale, ...getPageLocales(page)], acceptLanguage);
+    }
+
+    next();
+  };
+};
+
+const getStaticServerMiddleware = staticResources =>
+  (req, res, next) => {
+    if (req.url === "@404")
+      next();
+
+    const staticFile = path.join(publicDir, req.url);
+    const {ext} = path.parse(staticFile);
+    const {encoding, type} = staticResources[ext] || {};
+    if (!type) { //this file type is not supported
+      return next();
+    }
+
+    if (!fileExistsSync(staticFile)) {
+      req.url = "@404";
+      return next();
+    }
+
+    const readStream = fs.createReadStream(staticFile);
+    writeResponse(res, readStream, encoding, type);
+    console.log('Served static: ', staticFile);
+
+    //TODO Cache?
+    //cacheFile(path.join(contentDir, page) + ext, readStream);
+
+  };
+
+const detectRequestedPage = (req, res, next) => {
+  if (req.url === "@404")
+    next();
+
+  const page = url.parse(req.url).pathname;
+  let {dir, name} = path.parse(page);
+
+  //It's not allowed to request index page explicitly by the name
+  if (name === "index") {
+    req.url = "@404";
+    return next();
+  }
+
+  if (name === req.locale || !name) {
+    req.page = "index";
+    return next();
+  }
+
+  const basePath = dir.split(path.sep).filter(part => part && part !== req.locale);
+  req.page = path.join(...basePath, name);
+
+  console.log(req.page);
+
+  next();
+};
+
+const detectPermalinkedPage = (req, res, next) => {
+  if (req.url === "@404")
+    next();
+
+  const {page} = req;
+
+  //Do not allow to serve the original location
+  //if the page has a permalink
+  if (isPagePermalinked(page)) {
+    req.url = "@404";
+    return next();
+  }
+
+  const permalink = getPermalinkedPage(page);
+
+  if (permalink)
+    req.page = permalink;
+
+  next();
+};
+
+const detectLocale = getLocaleMiddleware(multiLang);
+const serveStatic = getStaticServerMiddleware(staticResourcesMap);
+const requestHandler = composeMiddleware(logRequestUrl, detectLocale, serveStatic, detectRequestedPage, detectPermalinkedPage, onRequest);
 
 /**
  * Starts the HTTP or HTTPS server In order to start HTTPS server you will need
@@ -75,11 +176,11 @@ let runServer = (argv) =>
       key: fs.readFileSync(argv.k),
       cert: fs.readFileSync(argv.c)
     };
-    server = require("https").createServer(options, onRequest);
+    server = require("https").createServer(options, requestHandler);
   }
   else
   {
-    server = require("http").createServer(onRequest);
+    server = require("http").createServer(requestHandler);
   }
 
   let port = isHttps ? config.port.https : config.port.http;
@@ -145,71 +246,21 @@ function fileExistsSync(file)
  */
 function onRequest(req, res)
 {
-  let page = url.parse(req.url).pathname;
-  let locale = "";
-  if (multiLang)
-    locale = getLocaleFromPath(page);
+  let {locale, page} = req;
 
-  let {dir, name, ext} = path.parse(page);
-  dir = dir.split(path.sep);
-  dir.shift();
-
-  if (name == 404)
+  if (req.url === "@404") {
     res.statusCode = 404;
-
-  // Filter locales from the path and Name
-  dir = dir.filter((part) => part != locale);
-  if (name == locale)
-    name = "";
-
-  page = path.join(...dir, name);
-
-  if (isPagePermalinked(page))
-  {
-    request404Page(req, res);
-    return;
+    page = "404";
   }
 
-  if (getPermalinkedPage(page))
-    page = getPermalinkedPage(page);
-
-  const isPublicFile = fileExistsSync(path.join(publicDir, page) + ext);
-  // Do not allow extensions in the address, unless public
-  if (pageExtestions.includes(ext) && !isPublicFile)
-  {
-    writeError(res, 404);
-    return;
-  }
-
-  // Do not allow index in the address
-  if (!ext && name == "index")
-  {
-    request404Page(req, res);
-    return;
-  }
-
-  if (!ext && !(ext = findExtension(page)))
-  {
-    // Check for index page
-    const indexPage = path.join(page, "index");
-    if (ext = findExtension(indexPage))
-      page = indexPage;
-  }
+  const ext = findExtension(page); //Static with the explicit extension should be served outside this middleware
 
   let {encoding, type} = resourcesMap[ext] || {};
   if (!ext)
   {
-    ext = "";
+    // ext = "";
     // Fallback for files without extensions
     ({encoding, type} = resourcesMap[".txt"]);
-  }
-
-  // Prefer accept-language header if no locale in the path
-  if (multiLang && !locale)
-  {
-    const acceptLanguage = getHeaders(req)["accept-language"];
-    locale = getLocaleFromHeader([defaultLocale, ...getPageLocales(page)],
-                                 acceptLanguage);
   }
 
   let cachePath;
@@ -231,15 +282,6 @@ function onRequest(req, res)
       res.setHeader("Cache-Control", "max-age=86400");
       writeResponse(res, readStream, encoding, type);
     });
-  }
-  else if (isPublicFile)
-  {
-    const readStream = fs.createReadStream(path.join(publicDir, page) + ext);
-    writeResponse(res, readStream, encoding, type);
-
-    // Cache
-    if (isCache)
-      cacheFile(path.join(contentDir, page) + ext, readStream);
   }
   else if (pageExtestions.includes(ext) &&
           (!multiLang || isTranslated(page, locale) ||
@@ -466,7 +508,7 @@ function writeError(res, code, message)
  */
 function request404Page(req, res)
 {
-  req.url = "404";
+  req.url = "@404";
   onRequest(req, res);
 }
 


### PR DESCRIPTION
* Introduce simple middleware library
* introduce 3 middlewares before onRequest:
    * locale detection - calculates the locale to use
    * logger - logs the requested urls;
    * static server - serves static whitelisted files. does not pass the control further if already able to serve the static file, so this part is now separate.

* wraps the onRequest to work as a middleware. The idea is to move as much as possible from there to have separate easily testable steps.